### PR TITLE
Corrected Spells: "KiCod" replaced with "KiCad" 

### DIFF
--- a/content/posts/ci-cd-with-kicad-and-gitlab/index.md
+++ b/content/posts/ci-cd-with-kicad-and-gitlab/index.md
@@ -23,7 +23,7 @@ resources:
 
 
 
-tags: ["PCB", "KiCod", "EE", "Gitlab", "JLCPCB", "LCSC"]
+tags: ["PCB", "KiCad", "EE", "Gitlab", "JLCPCB", "LCSC"]
 categories: ["projects"]
 
 toc:


### PR DESCRIPTION
Just a tiny little detail that I noticed and thought it would be awesome if fixed.
So there it is.
"KiCod" replaced with "KiCad" in index.md/tags (line 26)